### PR TITLE
Changed phpseclib requirement to composer alias for dependency managemen...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/process": "~2.6",
         "elfet/php-ssh": "~1.0",
         "elfet/pure": "~1.1",
-        "phpseclib/phpseclib": "dev-php5",
+        "phpseclib/phpseclib": "~2.0-dev",
         "kherge/amend": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Change the requirement to ~2.0-dev as composer gives some issues when you specify the branch.

@elfet could you tag this 2.0.1 in the master?